### PR TITLE
Fix: Prevent duplicate artifact deploys

### DIFF
--- a/deployment/apheleia-operator/rbac.yaml
+++ b/deployment/apheleia-operator/rbac.yaml
@@ -14,6 +14,9 @@ rules:
       - rebuiltartifacts
       - rebuiltartifacts/status
       - rebuiltartifacts/finalizers
+      - dependencybuilds
+      - dependencybuilds/status
+      - dependencybuilds/finalizers
     verbs:
       - create
       - delete


### PR DESCRIPTION
This fix deduplicates artifact deploys for RebuiltArtifacts by looking at the parent DependencyBuild